### PR TITLE
add Move migration support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,15 @@
 .PHONY: run
 run:
 	python3 pokedex/manage.py runserver
+
+.PHONY: build
+build:
+	echo "stub"
+
+.PHONY: clean
+clean:
+	echo "stub"
+
+.PHONY: test-build
+test-build:
+	echo "stub"

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ JSON payload example:
 }
 ```
 
+## Generating Authentic Pokemon Data
+We query PokeAPI's interface in order to extract legitimate data about pokemon. To set up your server with legitimate pokemon information, run `make build` in another terminal while the server is running.
+
+## Generating sample data for all tables
+We provide another Makefile command, `make test-build`, which will provide fake information about trainers, pokemon, and other classes relevant to the database.
+
+## Clearing the database
+To clean up your database, simply run `make clean` in another terminal while the server is running.
+
+
 # Authors
 - Natalie Hsu
 - Kevin Hui

--- a/pokeapi/api_importer.py
+++ b/pokeapi/api_importer.py
@@ -1,0 +1,39 @@
+"""
+A module that will import PokeAPI data into the pokedex's database. This
+module contacts the backend server and uses the appropriate API calls to
+import the data.
+"""
+from pokeapi import api
+
+import environ
+import os
+import requests
+import posixpath
+
+env = environ.Env()
+environ.Env.read_env("pokedex/pokedex/.env")
+
+DB_HOST = env('DATABASE_HOST')
+POKEMON_PREFIX = "pokemon"
+MOVE_PREFIX = "moves"
+CREATE = "create"
+
+def migrate_moves() -> None:
+    """
+    Migrates move information into the MySQL database.
+    :raises: Error if there is any issue with importing move data
+    """
+    moves = api.get_all_moves()
+
+    for move in moves:
+        response = requests.post(_format_path(DB_HOST, [POKEMON_PREFIX, MOVE_PREFIX, CREATE]), json=move)
+
+        if response.status_code != 200:
+            raise ValueError("Unexpected error when importing move data, error code: {}".format(response.status_code))
+
+def _format_path(base, components):
+    url = "http://{}:8000/".format(base)
+
+    for component in components:
+        url = posixpath.join(url, component)
+    return url + "/" if url[-1] != "/" else url

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ mysqlclient==2.1.0
 pytz==2021.3
 requests==2.26.0
 sqlparse==0.4.2
+Unidecode==1.3.2
 urllib3==1.26.7


### PR DESCRIPTION
NOTE: this will be merged after #16 
Provides the functionality for migrating moves into the database.

First, ensure the server is running in another terminal via `make run`

To run the migration, first import the method, e.g. from the project directory:
`from pokeapi import api_importer`

Then, run the migration method:
`api_importer.migrate_moves()`

Afterwards, wait a few minutes (it's importing all of the moves on their database!!)

Results:
![image](https://user-images.githubusercontent.com/24576987/144164238-3b6478ea-5534-45fd-abcb-1b0b3e751081.png)


![image](https://user-images.githubusercontent.com/24576987/144164279-48b000a3-c5e1-4c71-9bc7-602ccd98fc2b.png)
