### PR TITLE
add support for importing pokemon info

### DIFF
--- a/pokeapi/api_importer.py
+++ b/pokeapi/api_importer.py
@@ -8,6 +8,7 @@ from pokeapi import api
 import environ
 import requests
 import posixpath
+import logging
 
 env = environ.Env()
 environ.Env.read_env("pokedex/pokedex/.env")
@@ -15,13 +16,15 @@ environ.Env.read_env("pokedex/pokedex/.env")
 DB_HOST = env('DATABASE_HOST')
 POKEMON_PREFIX = "pokemon"
 MOVE_PREFIX = "moves"
+POKEMON_INFO_PREFIX = "pokemon_info"
 CREATE = "create"
-
+logger = logging.getLogger("api_importer")
 def migrate_moves() -> None:
     """
     Migrates move information into the MySQL database.
     :raises: Error if there is any issue with importing move data
     """
+    logger.info("Importing moves...")
     moves = api.get_all_moves()
 
     for move in moves:
@@ -29,6 +32,23 @@ def migrate_moves() -> None:
 
         if response.status_code != 200:
             raise ValueError("Unexpected error when importing move data, error code: {}".format(response.status_code))
+    logger.info("moves successfully imported")
+
+def migrate_pokemon_info() -> None:
+    """
+    Migrates pokemon information into the MySQL database.
+    
+    :raises: Error if there is any issue with importing pokemon information
+    """
+    logger.info("Importing pokemon info...")
+    pokemon_info = api.get_all_pokemon_info()
+
+    for pokemon in pokemon_info:
+        response = requests.post(_format_path(DB_HOST, [POKEMON_PREFIX, POKEMON_INFO_PREFIX, CREATE]), json=pokemon)
+
+        if response.status_code != 200:
+            raise ValueError("Unexpected error when importing move data, error code: {}".format(response.status_code))
+    logger.info("pokemon info successfully imported")
 
 def _format_path(base, components):
     url = "http://{}:8000/".format(base)

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -21,7 +21,8 @@ def main():
 
     logger.info("Downloading moves...")
     api_importer.migrate_moves()
-
+    logger.info("Download pokemon information...")
+    api_importer.migrate_pokemon_info()
     logger.info("Download complete.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support added for importing all pokemon info. Caveats:
- I did not add support for grouping pokemon info in a series (evolution series). This will come in a follow up PR
- Thanks to troublesome Unicode decoding when querying the PokeAPI website, some strings in the descriptions might contain weird quirks like relics of hexadecimal strings (e.g. \xab). I filtered out a few of them but there could be some floating around
- Types, weaknesses, and region support has not been supported yet. These will all come in future PRs as we add further support to those classes.

```
(env) ➜  db-pokedex-backend git:(pull-pokemon-info) ✗ make build
python3 scripts/download_data.py
INFO:download_data:Downloading moves...
INFO:download_data:Download pokemon information...
INFO:pokeapi:Retrieving all pokemon data.
INFO:pokeapi:Querying API for pokemon data
INFO:pokeapi:Finished querying pokemon.
INFO:download_data:Download complete.
```

Some moves imported:
![image](https://user-images.githubusercontent.com/24576987/144525231-8e3d9d7a-a4bf-4c7a-9016-ccd4759622b4.png)


Some pokemon info imported:
![image](https://user-images.githubusercontent.com/24576987/144525269-70555cc1-9e5c-4902-afe3-c4eb20646ee1.png)
