### PR TITLE
add move associations to make build

### DIFF
--- a/pokeapi/api.py
+++ b/pokeapi/api.py
@@ -55,6 +55,11 @@ def get_all_pokemon_info() -> List[Dict[str, Any]]:
                 return sprites_dict['front_default']
         return sprites_dict['front_default']
 
+    def process_move(move_entry):
+        # Extract the move number from the provided url
+        url = move_entry['url']
+        return int(url.split("/")[-2])
+
     def process_pokemon_data(pokemon_entry):
         # Processes the pokemon data for specific attributes we care about
         species = _get_pokemon_species(pokemon_entry['species']['url'])
@@ -72,7 +77,8 @@ def get_all_pokemon_info() -> List[Dict[str, Any]]:
             "national_num": pokemon_entry['id'],
             "name": pokemon_entry['name'],
             "description": eng_desc,
-            "photo_url": get_photo_url(pokemon_entry['sprites'])
+            "photo_url": get_photo_url(pokemon_entry['sprites']),
+            "moves": [process_move(move['move']) for move in pokemon_entry['moves']]
         }
         return new_pokemon_data
 

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -22,7 +22,9 @@ def main():
     logger.info("Downloading moves...")
     api_importer.migrate_moves()
     logger.info("Download pokemon information...")
-    api_importer.migrate_pokemon_info()
+    pokemon_info = api_importer.migrate_pokemon_info()
+    logger.info("Associating pokemon information with their moves...")
+    api_importer.associate_pokemon_info_with_moves(pokemon_info)
     logger.info("Download complete.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Enables pokemon that have been downloaded to have their moves associated with them.

This PR only considers at most 10 move entries because quite frankly, there are too many moves for this to practically associate all of them in a reasonable amount of time

Closes #32 