### PR TITLE
add evolution chain migration

### DIFF
--- a/pokeapi/api.py
+++ b/pokeapi/api.py
@@ -81,10 +81,6 @@ def get_all_pokemon_info() -> List[Dict[str, Any]]:
             "photo_url": get_photo_url(pokemon_entry['sprites']),
             "moves": [process_move(move['move']) for move in pokemon_entry['moves']]
         }
-
-        if species['predecessor']:
-            # There is some sort of predecessor entry, we need to manually connect the two entries
-            new_pokemon_data['predecessor'] = int(species['predecessor']['url'].split('/')[-2])
         if species['evolution_chain']:
             new_pokemon_data['evolution_chain'] = species['evolution_chain']
         return new_pokemon_data
@@ -251,7 +247,6 @@ def _get_pokemon_species(species_url: str) -> Dict[str, str]:
     species['names'] = _filter_eng(species['names'])
     species['genera'] = _filter_eng(species['genera'])
     species['flavor_text_entries'] = _filter_eng(species['flavor_text_entries'])
-    species['predecessor'] = species['evolves_from_species']
     if 'evolution_chain' in species:
         species['evolution_chain'] = int(species['evolution_chain']['url'].split('/')[-2])
     return species

--- a/pokeapi/api.py
+++ b/pokeapi/api.py
@@ -13,6 +13,7 @@ POKEAPI_URL_PREFIX = "https://pokeapi.co/api/v2/"
 POKEMON_API_PREFIX = "pokemon/"
 POKEMON_MOVE_PREFIX = "move/"
 REGION_PREFIX = "region/"
+EVOLUTION_CHAIN = "evolution-chain/"
 REGIONS = ["Kanto", "Johto", "Hoenn", "Sinnoh", "Unova", "Kalos", "Alola", "Galar"]
 logger = logging.getLogger("pokeapi")
 
@@ -80,6 +81,12 @@ def get_all_pokemon_info() -> List[Dict[str, Any]]:
             "photo_url": get_photo_url(pokemon_entry['sprites']),
             "moves": [process_move(move['move']) for move in pokemon_entry['moves']]
         }
+
+        if species['predecessor']:
+            # There is some sort of predecessor entry, we need to manually connect the two entries
+            new_pokemon_data['predecessor'] = int(species['predecessor']['url'].split('/')[-2])
+        if species['evolution_chain']:
+            new_pokemon_data['evolution_chain'] = species['evolution_chain']
         return new_pokemon_data
 
     logger.info("Querying API for pokemon data")
@@ -154,6 +161,30 @@ def get_all_moves() -> List[Dict[str, str]]:
     move_links = _get_all_move_links()
     return [_get_move(move_link) for move_link in move_links]
 
+def get_evolution_chain_data(evolution_chain: int) -> List[int]:
+    """
+    Returns the evolution chain from the id of the evolution chain. This is a list of
+    national_nums for each of the corresponding pokemon.
+    """
+    api_query = urljoin(POKEAPI_URL_PREFIX, EVOLUTION_CHAIN)
+    api_query = "{}{}".format(api_query, evolution_chain)
+    response = requests.get(api_query)
+    if response.status_code != 200:
+        raise ValueError("Error code when finding evolution chain: {}, URL attempted: {}".format(response.status_code, api_query))
+
+    evolution_chain = response.json()
+    chain = evolution_chain['chain']
+    result = []
+
+    while chain:
+        result.append(int(chain['species']['url'].split('/')[-2]))
+
+        if chain['evolves_to']:
+            chain = chain['evolves_to'][0]
+        else:
+            break
+    return result
+
 def _get_all_move_links() -> List[str]:
     """
     Retrieves all the API endpoint links represented by PokeAPI's move API. The list of strings returned are
@@ -220,6 +251,9 @@ def _get_pokemon_species(species_url: str) -> Dict[str, str]:
     species['names'] = _filter_eng(species['names'])
     species['genera'] = _filter_eng(species['genera'])
     species['flavor_text_entries'] = _filter_eng(species['flavor_text_entries'])
+    species['predecessor'] = species['evolves_from_species']
+    if 'evolution_chain' in species:
+        species['evolution_chain'] = int(species['evolution_chain']['url'].split('/')[-2])
     return species
 
 def _filter_eng(entries: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/pokeapi/api_importer.py
+++ b/pokeapi/api_importer.py
@@ -98,8 +98,6 @@ def migrate_evolution_chains(pokemon_list: List[Dict[str, Any]]) -> None:
                 raise ValueError("Error when updating the evolution chain, status code: {}, pokemon national_num: {}".format(response.status_code, chain[i]))
     logger.info("evolution chains successfully imported")
 
-
-
 def associate_pokemon_info_with_moves(pokemon_info: List[Dict[str, Any]]) -> None:
     """
     Associates the pokemon information in the database with all of the moves they are associated with.

--- a/pokeapi/api_importer.py
+++ b/pokeapi/api_importer.py
@@ -19,6 +19,7 @@ POKEMON_PREFIX = "pokemon"
 MOVE_PREFIX = "moves"
 POKEMON_INFO_PREFIX = "pokemon_info"
 CREATE = "create"
+UPDATE = "update"
 ASSOCIATE = "associate"
 logger = logging.getLogger("api_importer")
 def migrate_moves() -> None:
@@ -54,6 +55,50 @@ def migrate_pokemon_info() -> List[Dict[str, Any]]:
 
     logger.info("pokemon info successfully imported")
     return pokemon_info
+
+def migrate_evolution_chains(pokemon_list: List[Dict[str, Any]]) -> None:
+    """
+    Connects each pokemon with their new predecessors and successors from the provided evolution chain.
+
+    :raises: Error if there's an issue connecting each of the Pokemon in the evolution chain
+    """
+
+    pokemon_list = [pokemon for pokemon in pokemon_list if 'evolution_chain' in pokemon]
+    evolution_chain_set = set([pokemon['evolution_chain'] for pokemon in pokemon_list])
+    logger.info("creating evolution chains")
+    chains = []
+    for evolution_chain in evolution_chain_set:
+        chains.append(api.get_evolution_chain_data(evolution_chain))
+
+    logger.info("evolution chains successfully establishing, migrating in database")
+
+    for chain in chains:
+        if len(chain) <= 1:
+            continue
+
+        for i in range(len(chain)):
+            if i == 0:
+                updated_pokemon = {
+                    "national_num": chain[i],
+                    "evolved_state_pkid": chain[i+1]
+                }
+            elif i == len(chain)-1:
+                updated_pokemon = {
+                    "national_num": chain[i],
+                    "devolved_state_pkid": chain[i-1]
+                }
+            else:
+                updated_pokemon = {
+                    "national_num": chain[i],
+                    "evolved_state_pkid": chain[i+1],
+                    "devolved_state_pkid": chain[i-1]
+                }
+            response = requests.post(_format_path(DB_HOST, [POKEMON_PREFIX, POKEMON_INFO_PREFIX, UPDATE, str(chain[i])]), json=updated_pokemon)
+            if response.status_code != 200:
+                raise ValueError("Error when updating the evolution chain, status code: {}, pokemon national_num: {}".format(response.status_code, chain[i]))
+    logger.info("evolution chains successfully imported")
+
+
 
 def associate_pokemon_info_with_moves(pokemon_info: List[Dict[str, Any]]) -> None:
     """

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -23,6 +23,8 @@ def main():
     api_importer.migrate_moves()
     logger.info("Download pokemon information...")
     pokemon_info = api_importer.migrate_pokemon_info()
+    logger.info("Forming evolution chains for pokemon...")
+    api_importer.migrate_evolution_chains(pokemon_info)
     logger.info("Associating pokemon information with their moves...")
     api_importer.associate_pokemon_info_with_moves(pokemon_info)
     logger.info("Download complete.")


### PR DESCRIPTION
Migration support for evolution chains, enabling us to automatically add evolution chains from the PokeAPI website

```zsh
(env) ➜  db-pokedex-backend git:(add-evolution-chain-migration) ✗ make build
python3 scripts/download_data.py
INFO:download_data:Downloading moves...
INFO:api_importer:Importing moves...
INFO:pokeapi:844 moves detected from PokeAPI, querying...
INFO:api_importer:moves successfully imported
INFO:download_data:Download pokemon information...
INFO:api_importer:Importing pokemon info...
INFO:pokeapi:Retrieving all pokemon data.
INFO:pokeapi:Querying API for pokemon data
INFO:pokeapi:Finished querying pokemon.
INFO:api_importer:pokemon info successfully imported
INFO:download_data:Forming evolution chains for pokemon...
INFO:api_importer:creating evolution chains
INFO:api_importer:evolution chains successfully establishing, migrating in database
INFO:api_importer:evolution chains successfully imported
INFO:download_data:Associating pokemon information with their moves...
INFO:download_data:Download complete.
```