### PR TITLE
add migration support for pokemon types

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Example payload:
 ```json
 {
     "type": "electric",
-    "pokemon_info": 25
+    "national_num": 25
 }
 ```
 

--- a/pokeapi/api.py
+++ b/pokeapi/api.py
@@ -79,7 +79,8 @@ def get_all_pokemon_info() -> List[Dict[str, Any]]:
             "name": pokemon_entry['name'],
             "description": eng_desc,
             "photo_url": get_photo_url(pokemon_entry['sprites']),
-            "moves": [process_move(move['move']) for move in pokemon_entry['moves']]
+            "moves": [process_move(move['move']) for move in pokemon_entry['moves']],
+            "types": pokemon_entry['types']
         }
         if species['evolution_chain']:
             new_pokemon_data['evolution_chain'] = species['evolution_chain']
@@ -87,6 +88,7 @@ def get_all_pokemon_info() -> List[Dict[str, Any]]:
 
     logger.info("Querying API for pokemon data")
     pokemon_raw_data = add_pokemon_url(api_query)
+    logger.info("Processing pokemon data")
     return [process_pokemon_data(pokemon) for pokemon in pokemon_raw_data]
 
 def get_pokemon_info(national_num: Union[int, str]) -> dict:

--- a/pokeapi/api_importer.py
+++ b/pokeapi/api_importer.py
@@ -18,6 +18,7 @@ DB_HOST = env('DATABASE_HOST')
 POKEMON_PREFIX = "pokemon"
 MOVE_PREFIX = "moves"
 POKEMON_INFO_PREFIX = "pokemon_info"
+POKEMON_TYPE_PREFIX = "pokemon_type"
 CREATE = "create"
 UPDATE = "update"
 ASSOCIATE = "associate"
@@ -55,6 +56,26 @@ def migrate_pokemon_info() -> List[Dict[str, Any]]:
 
     logger.info("pokemon info successfully imported")
     return pokemon_info
+
+def associate_pokemon_info_with_type(pokemon_list: List[Dict[str, Any]]) -> None:
+    """
+    Associates a pokemon with their natural element types.
+
+    :raises: Error if there's an issue associating a pokemon with their element types
+    """
+    logger.info("Starting pokemon type association process")
+    for pokemon in pokemon_list:
+        for t in pokemon['types']:
+            pokemon_type = t['type']['name']
+            type_assoc = {
+                "type": pokemon_type,
+                "national_num": int(pokemon['national_num'])
+            }
+            response = requests.post(_format_path(DB_HOST, [POKEMON_PREFIX, POKEMON_TYPE_PREFIX, CREATE]), json=type_assoc)
+            if response.status_code != 200:
+                raise ValueError("Unexpected error when associating types for pokemon info, error code: {}".format(response.status_code))
+
+    logger.info("All pokemon types successfully associated")
 
 def migrate_evolution_chains(pokemon_list: List[Dict[str, Any]]) -> None:
     """

--- a/scripts/download_data.py
+++ b/scripts/download_data.py
@@ -23,6 +23,8 @@ def main():
     api_importer.migrate_moves()
     logger.info("Download pokemon information...")
     pokemon_info = api_importer.migrate_pokemon_info()
+    logger.info("Associating pokemon with their given types...")
+    api_importer.associate_pokemon_info_with_type(pokemon_info)
     logger.info("Forming evolution chains for pokemon...")
     api_importer.migrate_evolution_chains(pokemon_info)
     logger.info("Associating pokemon information with their moves...")


### PR DESCRIPTION
Provides migration support for pokemon types from the PokeAPI website.

Closes #27 